### PR TITLE
add lodash dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,9 @@
             {
                 "paths": {
                     "angular-google-maps": "angular-google-maps"
-                    "lodash-undersore": "lodash.undersore"
                 },
                 "shim": {
-                    "angular-google-maps": ["angularjs"]
-                    "lodash-undersore": ["lodash.underscore"]
+                    "angular-google-maps": ["angularjs", "lodash-underscore"]
                 }
             }
         </requirejs>


### PR DESCRIPTION
lodash.underscore.js is a needed dependency of angular-google-maps. is there a way to specify lodash.undescore only as a dependency?
