### PR TITLE
Fix destDir to use webjar version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angular-google-maps</artifactId>
-    <version>1.2.0-2-SNAPSHOT</version>
+    <version>1.2.0-2</version>
     <name>angular-google-maps</name>
     <description>WebJar for angular-google-maps</description>
     <url>http://webjars.org</url>
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstream.version>1.2.0</upstream.version>
         <upstream.url>https://raw.githubusercontent.com/angular-ui/angular-google-maps/${upstream.version}/dist</upstream.url>
-        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
+        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${version}</destDir>
         <requirejs>
             {
                 "paths": {
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>lodash</artifactId>
-            <version>2.4.1-5</version>
+            <version>2.4.1-6</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
Bump lodash dependency.
Trying to figure out how your versioning system works. Would that do?
